### PR TITLE
change git clone command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Node v8 (lts/carbon) or later is recommended.
 
 ```shell
 # clone repository and install dependencies
-git clone git@github.com:tracespace/tracespace.git
+git clone https://github.com/tracespace/tracespace
 cd tracespace
 npm install
 ```


### PR DESCRIPTION
updated git clone command for user end , 
earlier it would give error

git clone git@github.com:tracespace/tracespac
e.git
Cloning into 'tracespace'...
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? y
Please type 'yes' or 'no': yes
Warning: Permanently added 'github.com,192.30.253.112' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.